### PR TITLE
Fix for timeURL

### DIFF
--- a/src/dme/forecastiolib/ForecastIO.java
+++ b/src/dme/forecastiolib/ForecastIO.java
@@ -334,7 +334,7 @@ public class ForecastIO {
 		url += ForecastIOApiKey+"/";
 		url += LATITUDE+","+LONGITUDE;
 		if(timeURL!=null)
-			url += timeURL;
+			url += ","+timeURL;
 		url += "?units="+unitsURL;
 		if(excludeURL!=null)
 			url += "&exclude="+excludeURL;


### PR DESCRIPTION
Per the ForecastIO API Docs ( https://developer.forecast.io/docs/v2#time_call ) time should be added to the request URL with a comma separator. 

Matt
