### PR TITLE
add summary and icon to minutely forecast

### DIFF
--- a/src/com/github/dvdme/ForecastIOLib/FIOMinutely.java
+++ b/src/com/github/dvdme/ForecastIOLib/FIOMinutely.java
@@ -38,5 +38,21 @@ public class FIOMinutely {
 	public int minutes(){
 		return this.minutely == null ? -1 : this.minutely.datablockSize();
 	}
+	
+	/**
+	 * Returns forecast summary
+	 * @return forecast summary or null
+	 */
+	public String getSummary() {
+		return minutely == null ? null : minutely.summary();
+	}
+	
+	/**
+	 * Returns forecast icon
+	 * @return forecast icon or null
+	 */
+	public String getIcon() {
+		return minutely == null ? null : minutely.icon();
+	}
 
 }


### PR DESCRIPTION
This adds `getSummary()` & `getIcon()` methods for minutely data object.
see: `https://api.darksky.net/forecast/API_KEY/25.7616798,-80.19179020000001?units=auto&lang=en`