### PR TITLE
Added a function: export to CSV

### DIFF
--- a/src/com/github/dvdme/ForecastIOLib/FIODataPoint.java
+++ b/src/com/github/dvdme/ForecastIOLib/FIODataPoint.java
@@ -54,7 +54,7 @@ public class FIODataPoint {
 
 	/**
 	 * Returns a String array with all the Forecast.io fields available
-	 * in this data point. It can be usefull to iterate over all
+	 * in this data point. It can be useful to iterate over all
 	 * available fields in a data point.
 	 * 
 	 * @return the String array with the field's names.
@@ -98,7 +98,11 @@ public class FIODataPoint {
 		if(key.contains("Time")){
 			DateFormat dfm = new SimpleDateFormat("HH:mm:ss");
 			dfm.setTimeZone(TimeZone.getTimeZone(timezone));
-			out = dfm.format( Long.parseLong(String.valueOf(this.datapoint.get(key))) * 1000 );
+			
+			if(this.datapoint.get(key) != null)
+				out = dfm.format( Long.parseLong(String.valueOf(this.datapoint.get(key))) * 1000 );
+			else
+				out = null;
 		}
 		else 
 			out = String.valueOf( datapoint.get(key) );

--- a/src/com/github/einstein29/csv/FIOCsv.java
+++ b/src/com/github/einstein29/csv/FIOCsv.java
@@ -1,0 +1,270 @@
+/**
+ * This class exports data to csv file.
+ * 
+ * @author Rui Gong
+ */
+
+package com.github.einstein29.csv;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+import com.github.dvdme.ForecastIOLib.FIOCurrently;
+import com.github.dvdme.ForecastIOLib.FIODaily;
+import com.github.dvdme.ForecastIOLib.FIOHourly;
+import com.github.dvdme.ForecastIOLib.FIOMinutely;
+
+public class FIOCsv {
+	
+	private String delimiter;
+	private String filePath; 
+	
+	private static final String[] namesForCurrently = { "time", "summary",
+			"icon", "nearestStormDistance", "precipIntensity",
+			"precipIntensityError", "precipProbability", "precipType",
+			"temperature", "apparentTemperature", "dewPoint", "humidity",
+			"windSpeed", "windBearing", "visibility", "cloudCover", "pressure",
+			"ozone" };
+
+	private final String[] namesForMinutely = { "time", "precipIntensity",
+			"precipIntensityError", "precipProbability", "precipType" };
+
+	private final String[] namesForHourly = { "time", "summary", "icon",
+			"precipIntensity", "precipProbability", "precipType",
+			"temperature", "apparentTemperature", "dewPoint", "humidity",
+			"windSpeed", "windBearing", "visibility", "cloudCover", "pressure",
+			"ozone" };
+
+	private final String[] namesForDaily = { "time", "summary", "icon",
+			"sunriseTime", "sunsetTime", "moonPhase", "precipIntensity",
+			"precipIntensityMax", "precipIntensityMaxTime",
+			"precipProbability", "precipType", "temperatureMin",
+			"temperatureMinTime", "temperatureMax", "temperatureMaxTime",
+			"apparentTemperatureMin", "apparentTemperatureMinTime",
+			"apparentTemperatureMax", "apparentTemperatureMaxTime", "dewPoint",
+			"humidity", "windSpeed", "windBearing", "visibility", "cloudCover",
+			"pressure", "ozone" };
+	
+	public FIOCsv(String filePath){
+		this.filePath = filePath;
+		this.delimiter = ",";
+	}
+	
+	public FIOCsv(String filePath, String delimiter){
+		this.filePath = filePath;
+		this.delimiter = delimiter;
+	}
+	
+	/**
+	 * Writes header into csv file.
+	 * 
+	 * @param writer FileWriter, namesForTimeInterval String[].
+	 */
+	private void writeHeader(FileWriter writer, String[] namesForTimeInterval){
+		String name = "";
+		try{
+			for (int i = 0; i < namesForTimeInterval.length; i++){
+				name = namesForTimeInterval[i];
+				if(i != namesForTimeInterval.length-1){
+					writer.write(name+delimiter);
+				}else{
+					writer.write(name);
+				}
+			}
+			writer.write("\n");
+		}catch (IOException e) {
+			System.err.println("Failed when writing header to CSV file.");
+			e.printStackTrace();
+		}
+	}
+	
+	/**
+     * Writes currently data into csv file.
+     *
+     * @param  currently
+     *         A FIOCurrently object.
+     *
+     * @throws  IOException
+     *          If the file path or the writing process is corrupted.
+     */
+	public boolean writeToCsv(FIOCurrently currently) {
+		String data = "";
+		FileWriter writer = null;
+		try {
+			writer = new FileWriter(filePath);
+			writeHeader(writer, namesForCurrently);
+
+			// Writes contents.
+			for (int j = 0; j < namesForCurrently.length; j++) {
+				data = currently.get().getByKey(namesForCurrently[j]);
+				if (j != namesForCurrently.length - 1) {
+					writer.write(data + delimiter);
+				} else {
+					writer.write(data);
+				}
+			}
+		} catch (IOException e) {
+			System.err.println("Failed when writing contents to CSV file.");
+			e.printStackTrace();
+		} finally {
+			try {
+				writer.close();
+			} catch (IOException e) {
+				System.err.println("FileWriter does not close properly.");
+				e.printStackTrace();
+				return false;
+			}
+		}
+		System.out.println("Done. Current weather data has been written into csv file.");
+		return true;
+	}
+	
+	/**
+     * Writes minutely data into csv file.
+     *
+     * @param  minutely
+     *         A FIOMinutely object.
+     *
+     * @throws  IOException
+     *          If the file path or the writing process is corrupted.
+     */
+	public boolean writeToCsv(FIOMinutely minutely){
+		if(minutely.minutes()<0){
+			System.out.println("No minutely data, nothing will be written.");
+			return false;
+		}
+		
+		String data = "";
+		FileWriter writer = null;
+		try {
+			writer = new FileWriter(filePath);
+			writeHeader(writer, namesForMinutely);
+
+			// Writes contents.
+			for(int i = 0; i<minutely.minutes(); i++){
+				for(int j=0; j<namesForMinutely.length; j++){
+					data = minutely.getMinute(i).getByKey(namesForMinutely[j]);
+					if(j != namesForMinutely.length-1){
+						writer.write(data+delimiter);
+					}else{
+						writer.write(data);
+					}
+				}
+				writer.write("\n");
+			}
+
+		} catch (IOException e) {
+			System.err.println("Failed when writing contents to CSV file.");
+			e.printStackTrace();
+		}finally{
+			try {
+				writer.close();
+			} catch (IOException e) {
+				System.out.println("FileWriter does not close properly.");
+				e.printStackTrace();
+				return false;
+			}
+		}
+		System.out.println("Done. Minutely weather data has been written into csv file.");
+		return true;
+	}
+	
+	/**
+     * Writes hourly data into csv file.
+     *
+     * @param  hourly
+     *         A FIOHourly object.
+     *
+     * @throws  IOException
+     *          If the file path or the writing process is corrupted.
+     */
+	public boolean writeToCsv(FIOHourly hourly){
+		if(hourly.hours()<0){
+			System.out.println("No hourly data, nothing will be written.");
+			return false;
+		}
+		
+		String data = "";
+		FileWriter writer = null;
+		try {
+			writer = new FileWriter(filePath);
+			writeHeader(writer, namesForHourly);
+			
+			// Write contents.
+			for(int i = 0; i<hourly.hours(); i++){
+				for(int j=0; j<namesForHourly.length; j++){
+					data = hourly.getHour(i).getByKey(namesForHourly[j]);
+					if(j != namesForHourly.length-1){
+						writer.write(data+delimiter);
+					}else{
+						writer.write(data);
+					}
+				}
+				writer.write("\n");
+			}
+		} catch (IOException e) {
+			System.err.println("Failed when writing contents to CSV file.");
+			e.printStackTrace();
+		}finally{
+			try {
+				writer.close();
+			} catch (IOException e) {
+				System.out.println("FileWriter does not close properly.");
+				e.printStackTrace();
+				return false;
+			}
+		}
+		System.out.println("Done. Hourly weather data has been written into csv file.");
+		return true;
+	}
+		
+	/**
+     * Writes daily data into csv file.
+     *
+     * @param  daily
+     *         A FIODaily object.
+     *
+     * @throws  IOException
+     *          If the file path or the writing process is corrupted.
+     */
+	public boolean writeToCsv(FIODaily daily){
+		if(daily.days()<0){
+			System.out.println("No daily data, nothing will be written.");
+			return false;
+		}
+		
+		String data = "";
+		FileWriter writer = null;
+        try {
+			writer = new FileWriter(filePath);
+			writeHeader(writer, namesForDaily);
+			
+			// Writes contents.
+			for(int i = 0; i<daily.days(); i++){
+				for(int j=0; j<namesForDaily.length; j++){
+					data = daily.getDay(i).getByKey(namesForDaily[j]);
+					if(j != namesForDaily.length-1){
+						writer.write(data+delimiter);
+					}else{
+						writer.write(data);
+					}
+				}
+				writer.write("\n");
+			}
+			
+		} catch (IOException e) {
+			System.err.println("Failed when writing contents to CSV file.");
+			e.printStackTrace();
+		}finally{
+			try {
+				writer.close();
+			} catch (IOException e) {
+				System.out.println("FileWriter does not close properly.");
+				e.printStackTrace();
+				return false;
+			}
+		}
+        System.out.println("Done. Daily weather data has been written into csv file.");
+        return true;
+	}
+}

--- a/src/com/github/einstein29/csv/FIOCsvTest.java
+++ b/src/com/github/einstein29/csv/FIOCsvTest.java
@@ -1,0 +1,72 @@
+package com.github.einstein29.csv;
+
+import com.github.dvdme.ForecastIOLib.FIOCurrently;
+import com.github.dvdme.ForecastIOLib.FIODaily;
+import com.github.dvdme.ForecastIOLib.FIOHourly;
+import com.github.dvdme.ForecastIOLib.FIOMinutely;
+import com.github.dvdme.ForecastIOLib.ForecastIO;
+
+public class FIOCsvTest {
+	
+	private static final String apikey = "APIKEY";
+
+	public static void main(String[] args) {
+
+		ForecastIO fio = new ForecastIO(apikey);
+		fio.setUnits(ForecastIO.UNITS_SI);
+		fio.setLang(ForecastIO.LANG_ENGLISH);
+		fio.getForecast("38.7252993" , "-9.1500364");
+
+		//Response Headers info
+		System.out.println("Response Headers:");
+		System.out.println("Cache-Control: "+fio.getHeaderCache_Control());
+		System.out.println("Expires: "+fio.getHeaderExpires());
+		System.out.println("X-Forecast-API-Calls: "+fio.getHeaderX_Forecast_API_Calls());
+		System.out.println("X-Response-Time: "+fio.getHeaderX_Response_Time());
+		System.out.println("\n");
+
+		//ForecastIO info
+		System.out.println("Latitude: "+fio.getLatitude());
+		System.out.println("Longitude: "+fio.getLongitude());
+		System.out.println("Timezone: "+fio.getTimezone());
+		System.out.println("Offset: "+fio.offsetValue());
+		System.out.println("\n");	
+		
+		
+
+		//Currently data
+		FIOCurrently currently = new FIOCurrently(fio);
+		
+		String filePathCurrently = "C:\\Users\\currently.csv";
+		FIOCsv fioCsvCurrently = new FIOCsv(filePathCurrently);
+		fioCsvCurrently.writeToCsv(currently);
+		
+		
+		
+		//Minutely data
+		FIOMinutely minutely = new FIOMinutely(fio);
+		
+		String filePathMinutely = "C:\\Users\\minutely.csv";
+		FIOCsv fioCsvMinutely = new FIOCsv(filePathMinutely);
+		fioCsvMinutely.writeToCsv(minutely);
+		
+		
+		
+		//Hourly data
+		FIOHourly hourly = new FIOHourly(fio);
+		
+		String filePathHourly = "C:\\Users\\hourly.csv";
+		FIOCsv fioCsvHourly = new FIOCsv(filePathHourly);
+		fioCsvHourly.writeToCsv(hourly);
+		
+		
+		
+		//Daily data
+		FIODaily daily = new FIODaily(fio);
+		
+		String filePathDaily = "C:\\Users\\daily.csv";
+		FIOCsv fioCsvDaily = new FIOCsv(filePathDaily);
+		fioCsvDaily.writeToCsv(daily);
+	}
+
+}

--- a/src/com/github/einstein29/csv/README.md
+++ b/src/com/github/einstein29/csv/README.md
@@ -1,0 +1,10 @@
+ForecastIO-Lib-Java
+===================
+
+- Added the ability to export Currently, Minutely, Hourly and Daily data to CSV. 
+
+ To my knowledge, the number of entries in a certain data block varies. For instance, hourly data may or may not contain the entry `visibility`, and daily data may or may not contain the entry `precipIntensityMaxTime`.
+
+Apparently, dvdme has already noticed it, and that is probably the reason for having a `getFieldsArray` before displaying data. In order to cover all entries, column names are pre-defined in `FIOCsv.java` based on the API provided [here](https://darksky.net/dev/docs/forecast). Non-existing entries will be replaced by `null` when writing to csv file. I have made one modification in `FIODataPoint.java` for the purpose of eliminating `NumberFormatException` when one of the entries involves the keyword **Time** does not exist in the returned JSON, such as `precipIntensityMaxTime`.
+
+Rui Gong


### PR DESCRIPTION
Added the ability to export Currently, Minutely, Hourly and Daily data to CSV. 

To my knowledge, the number of entries in a certain data block varies. For instance, hourly data may or may not contain the entry `visibility`, and daily data may or may not contain the entry `precipIntensityMaxTime`.

Apparently, dvdme has already noticed it, and that is probably the reason for having a `getFieldsArray` before displaying data. In order to cover all entries, column names are pre-defined in `FIOCsv.java` based on the API provided [here](https://darksky.net/dev/docs/forecast). Non-existing entries will be replaced by `null` when writing to csv file. I have made one modification in `FIODataPoint.java` for the purpose of eliminating `NumberFormatException` when one of the entries involves the keyword **Time** does not exist in the returned JSON, such as `precipIntensityMaxTime`.

Rui Gong
